### PR TITLE
Final pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,6 @@ This means that:
 
 ## But first...
 
-Why i do this? Because i want to use Kali Linux and don't get it be installed with 
-the default crouton installer. Also the development is not realy active, so i will
-try to make needed changes, to get kali linux (rolling) running again.
-
-To test and try, use the dev branch please, the testing branch is under active unsecure
-untested code for contibutors. An pull to master will be denied, because this is the origin
-clone of repo and many ppl surf via google to github and so they don't get confused or buggy/unsecure 
-code.
-
 :warning: **Steps to install crouton have changed!**  :warning:
 
 Due to improved security within Chromium OS ([yay!](https://chromium.googlesource.com/chromiumos/docs/+/HEAD/security/noexec_shell_scripts.md)),

--- a/targets/kalifix
+++ b/targets/kalifix
@@ -1,0 +1,42 @@
+#!/bin/sh -e
+# Copyright (c) 2022 The crouton Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+REQUIRES='core'
+DESCRIPTION='Fixes xbindkeys error during kali linux setup.'
+
+if release -le kali; then
+
+    # Adding debian bullseye repo to get xbindkeys installed
+    echo -e '\033[1mAdding debian bullseye repo to sources.list...'
+    cat >> /etc/apt/sources.list <<EOF
+deb http://ftp.halifax.rwth-aachen.de/debian bullseye main non-free contrib
+deb-src http://ftp.halifax.rwth-aachen.de/debian bullseye main non-free contrib
+EOF
+
+    # Update the package list.
+    # Ignore failures, as most are due to bad PPAs and are not critical.
+    echo -e '\033[1mUpdate the package list...'
+    apt-get -y -qq update || true
+
+    ### Install xbindkeys
+    echo -e '\033[1minstalling xbindkeys...'
+    apt -y -qq install xbindkeys xbindkeys-config
+
+    # Remove bullseye sources to exclude conflicts with future install steps
+    echo -e '\033[1mRemove bullseye sources...'
+    sh -c "head -n -2 /etc/apt/sources.list > /etc/apt/sources.list.tmp"
+    rm /etc/apt/sources.list
+    mv /etc/apt/sources.list.tmp /etc/apt/sources.list
+
+    echo -e '\033[1mUpdate the package list...'
+    apt-get -y -qq update
+
+    echo -e '\033[1mInstall kali core meta package...'
+    apt-get -y -qq install kali-linux-core
+
+    #TO-DO: - MOTD FIX (delete lines) /etc/profile.d/kali.sh
+
+    TIPS="$TIPS
+    The Kali Linux xbindkeys fix is installed in your chroot."
+fi


### PR DESCRIPTION
This is the **final** pull for the Kali Linux "xbindkeys" fix. This pull contains: 

- the creation of an target file. [3cf0d17](https://github.com/iptoux/crouton/commit/3cf0d1732016319fce929a16f83906be1ae0bf4d)
- change README.md back to origin. [fdd737f](https://github.com/iptoux/crouton/commit/fdd737f66557d29ec7626f8efddbe2a221cb8663)

